### PR TITLE
UnitTestのワークフロー名を変更

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,14 +5,14 @@
 # http://creativecommons.org/publicdomain/zero/1.0/deed.ja
 #
 
-name: for pull request
+name: check
 on:
   pull_request:
     types: [opened, synchronize]
 
 jobs:
   check_and_build:
-    name: Pull Request
+    name: lint/typecheck/unittest/build
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # magica_ime_dict
 
-![test](https://github.com/matunnkazumi/magica_ime_dict/actions?query=workflow%3A%22for+pull+request%22)
+[![test](https://github.com/matunnkazumi/magica_ime_dict/workflows/for%20pull%20request/badge.svg)](https://github.com/matunnkazumi/magica_ime_dict/actions?query=workflow%3A%22for+pull+request%22)
 
 ## ライセンス
 特に表記が無いファイルは MIT License です。

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # magica_ime_dict
 
-[![test](https://github.com/matunnkazumi/magica_ime_dict/workflows/for%20pull%20request/badge.svg)](https://github.com/matunnkazumi/magica_ime_dict/actions?query=workflow%3A%22for+pull+request%22)
+[![check](https://github.com/matunnkazumi/magica_ime_dict/workflows/check/badge.svg)](https://github.com/matunnkazumi/magica_ime_dict/actions?query=workflow%3A%22check%22)
 
 ## ライセンス
 特に表記が無いファイルは MIT License です。

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # magica_ime_dict
 
+![test](https://github.com/matunnkazumi/magica_ime_dict/actions?query=workflow%3A%22for+pull+request%22)
+
 ## ライセンス
 特に表記が無いファイルは MIT License です。


### PR DESCRIPTION
見栄えを考慮して変更

* 「pull_request」ってトリガー名として表示されているから冗長
* バッジに表示される名前は短めに