### PR TITLE
Yamlの読み方定義にひらがなチェック追加

### DIFF
--- a/spec/test_yaml_schema.rb
+++ b/spec/test_yaml_schema.rb
@@ -3,6 +3,7 @@
 require 'minitest/autorun'
 require 'json_schemer'
 require 'pathname'
+require_relative '../lib/dict/reader'
 
 class YamlSchemaValidation < Minitest::Test
   def test_validate
@@ -18,6 +19,17 @@ class YamlSchemaValidation < Minitest::Test
     end
   end
 
+  def test_yomi_hiragana
+    # JSON Schema の正規表現の仕様次第ではそっちに変更
+    schema_yaml_hash.each do |_schemer, yaml_list|
+      yaml_list.each do |yaml|
+        Reader.load(yaml).each do |person|
+          assert_person_yomi person
+        end
+      end
+    end
+  end
+
   private
 
   def schema_yaml_hash
@@ -29,5 +41,18 @@ class YamlSchemaValidation < Minitest::Test
       .reject { |schema_file| schema_file.start_with?('https://') }
       .transform_keys { |schema_file| Pathname(schema_file) }
       .transform_keys { |pathname| JSONSchemer.schema(pathname) }
+  end
+
+  PATTERN_YOMI = /^[\p{Hiragana}ー]+$/
+
+  def assert_person_yomi(person)
+    assert_match PATTERN_YOMI, person.dig(:sei, :yomi) unless person.dig(:sei, :yomi).nil?
+    assert_match PATTERN_YOMI, person.dig(:mei, :yomi) unless person.dig(:mei, :yomi).nil?
+
+    return unless person.key? :sonota
+
+    person[:sonota].each do |pair|
+      assert_match PATTERN_YOMI, pair[:yomi] if pair.key? :yomi
+    end
   end
 end


### PR DESCRIPTION
読み方はひらがなと長音符のみ

JSON Schemaの正規表現で対応できるかも知れないが、仕様は別途調べる。