### PR TITLE
gitattributes 修正

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -29,11 +29,11 @@ jobs:
       - name: gitattributes
         run: | 
           cat <<EOF > build/.gitattributes
-          magica_ime_data_MSIME.txt encoding=UTF-16LE-BOM eol=crlf
-          magica_ime_data_ATOK.txt encoding=UTF-16LE-BOM eol=crlf
-          magica_ime_data_Mac.txt encoding=UTF-8 eol=lf
-          magica_ime_data_GoogleIME.txt encoding=UTF-8 eol=crlf
-          SKK-JISYO.magica encoding=UTF-8 eol=lf
+          magica_ime_data_MSIME.txt encoding=UTF-16LE-BOM
+          magica_ime_data_ATOK.txt encoding=UTF-16LE-BOM
+          magica_ime_data_Mac.txt encoding=UTF-8
+          magica_ime_data_GoogleIME.txt encoding=UTF-8
+          SKK-JISYO.magica encoding=UTF-8
           EOF
       - name: snapshot
         uses: s0/git-publish-subdir-action@v2.4.0

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -29,11 +29,11 @@ jobs:
       - name: gitattributes
         run: | 
           cat <<EOF > build/.gitattributes
-          magica_ime_data_MSIME.txt encoding=UTF-16LE-BOM
-          magica_ime_data_ATOK.txt encoding=UTF-16LE-BOM
-          magica_ime_data_Mac.txt encoding=UTF-8
-          magica_ime_data_GoogleIME.txt encoding=UTF-8
-          SKK-JISYO.magica encoding=UTF-8
+          magica_ime_data_MSIME.txt encoding=UTF-16LE-BOM working-tree-encoding=UTF-16LE-BOM
+          magica_ime_data_ATOK.txt encoding=UTF-16LE-BOM working-tree-encoding=UTF-16LE-BOM
+          magica_ime_data_Mac.txt encoding=UTF-8 working-tree-encoding=UTF-8
+          magica_ime_data_GoogleIME.txt encoding=UTF-8 working-tree-encoding=UTF-8
+          SKK-JISYO.magica encoding=UTF-8 working-tree-encoding=UTF-8
           EOF
       - name: snapshot
         uses: s0/git-publish-subdir-action@v2.4.0


### PR DESCRIPTION
https://git-scm.com/docs/gitattributes

* eol はチェックアウト時に改行コードを変換するための指定だったので、変換したくないなら不要
* git側が認識する文字コードは working-tree-encoding で指定できるらしい