### PR TITLE
encoding設定からBOMを除去

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -29,8 +29,8 @@ jobs:
       - name: gitattributes
         run: | 
           cat <<EOF > build/.gitattributes
-          magica_ime_data_MSIME.txt encoding=UTF-16LE-BOM working-tree-encoding=UTF-16LE-BOM
-          magica_ime_data_ATOK.txt encoding=UTF-16LE-BOM working-tree-encoding=UTF-16LE-BOM
+          magica_ime_data_MSIME.txt encoding=UTF-16LE working-tree-encoding=UTF-16LE-BOM
+          magica_ime_data_ATOK.txt encoding=UTF-16LE working-tree-encoding=UTF-16LE-BOM
           magica_ime_data_Mac.txt encoding=UTF-8 working-tree-encoding=UTF-8
           magica_ime_data_GoogleIME.txt encoding=UTF-8 working-tree-encoding=UTF-8
           SKK-JISYO.magica encoding=UTF-8 working-tree-encoding=UTF-8


### PR DESCRIPTION
https://git-scm.com/docs/gitattributes

* 使用できるエンコーディングは```iconv --list```で見れるそうだ
** Debian BusterのiconvにはUTF-16-BOMが無かった
** Git for Windows 2.29.2 の iconvにも無かった
* でも、上記の説明にはBOMがあるなら```-BOM```をつけろ、と。

というわけで、git guiなどが参照するがgit本体が無視するはずの```encoding```からは```-BOM```を取り除き、git本体が参照する```working-tree-encoding```には残しておく