### PR TITLE
Actionsのrunnerをubuntu-20.04 にする

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   check_and_build:
     name: lint/typecheck/unittest/build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   snapshot:
     name: build and save snapshot
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout
         uses: actions/checkout@v2.3.4


### PR DESCRIPTION
* gitattributes の working-tree-encoding は git の2.18.0以降
  * https://github.com/git/git/blob/master/Documentation/RelNotes/2.18.0.txt
* GitHubホストランナーのubuntu-latestはこれ書いてる時点だと、20.04か18.04のどちらか
  * https://docs.github.com/ja/actions/reference/workflow-syntax-for-github-actions#
![image](https://user-images.githubusercontent.com/22995774/109155341-c781f900-77b2-11eb-82d1-6711c4731801.png)

* Ubuntuの18.04のgitのバージョンは 2.17
  * https://packages.ubuntu.com/bionic/git
  * 20.04だと2.25 https://packages.ubuntu.com/focal/git

というわけで、Ubuntuのバージョンを上げる