### PR TITLE
snapshotの gittattribute 再修正

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -29,11 +29,11 @@ jobs:
       - name: gitattributes
         run: | 
           cat <<EOF > build/.gitattributes
-          magica_ime_data_MSIME.txt encoding=UTF-16LE working-tree-encoding=UTF-16LE-BOM
-          magica_ime_data_ATOK.txt encoding=UTF-16LE working-tree-encoding=UTF-16LE-BOM
-          magica_ime_data_Mac.txt encoding=UTF-8 working-tree-encoding=UTF-8
-          magica_ime_data_GoogleIME.txt encoding=UTF-8 working-tree-encoding=UTF-8
-          SKK-JISYO.magica encoding=UTF-8 working-tree-encoding=UTF-8
+          magica_ime_data_MSIME.txt working-tree-encoding=UTF-16LE-BOM
+          magica_ime_data_ATOK.txt working-tree-encoding=UTF-16LE-BOM
+          magica_ime_data_Mac.txt working-tree-encoding=UTF-8
+          magica_ime_data_GoogleIME.txt working-tree-encoding=UTF-8
+          SKK-JISYO.magica working-tree-encoding=UTF-8
           EOF
       - name: snapshot
         uses: s0/git-publish-subdir-action@v2.4.0

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -29,11 +29,11 @@ jobs:
       - name: gitattributes
         run: | 
           cat <<EOF > build/.gitattributes
-          magica_ime_data_MSIME.txt working-tree-encoding=UTF-16LE-BOM
-          magica_ime_data_ATOK.txt working-tree-encoding=UTF-16LE-BOM
-          magica_ime_data_Mac.txt working-tree-encoding=UTF-8
-          magica_ime_data_GoogleIME.txt working-tree-encoding=UTF-8
-          SKK-JISYO.magica working-tree-encoding=UTF-8
+          magica_ime_data_MSIME.txt working-tree-encoding=UTF-16LE-BOM eol=crlf
+          magica_ime_data_ATOK.txt working-tree-encoding=UTF-16LE-BOM eol=crlf
+          magica_ime_data_Mac.txt working-tree-encoding=UTF-8 eol=lf
+          magica_ime_data_GoogleIME.txt working-tree-encoding=UTF-8 eol=crlf
+          SKK-JISYO.magica working-tree-encoding=UTF-8 eol=lf
           EOF
       - name: snapshot
         uses: s0/git-publish-subdir-action@v2.4.0


### PR DESCRIPTION
#53 の変更を入れたので改めて

https://git-scm.com/docs/gitattributes

* working-tree-encoding ってのは、gitの内部データをutf-8に正規化するための設定
  * コミットするとutf-8に変換されて保存される
  * チェックアウトすると指定のエンコーディングに戻す
* 変換はiconvコマンドで行われる
  * ただし、UTF-16LE-BOM というエンコーディングは iconvにはない
  * git側で特殊な処理が入っている模様
    * https://github.com/git/git/blob/v2.25.0/utf8.c
* encodingはgit本体には関係ない。外部ツールが見るかも知れない値
  * 色々試した感じ、git gui は見ないっぽい感じ？
  * というわけで削除
    * まあ内部データを見るようなツールならあんまり関係ないんじゃないか？
* んでもって、もしかしてutf-16のファイルのeol=crlfが誤爆した原因て、working-tree-encoding なんじゃないか？
  * というわけでちょっと試しに戻してみる