### PR TITLE
スキーマの指定方法の修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,13 @@
     "https://json.schemastore.org/github-action": [
       "/github/workflows/*.yml"
     ],
-  }
+  },
+  "json.schemas": [
+    {
+      "fileMatch": [
+        "/schema/namelist.json"
+      ],
+      "url": "https://json-schema.org/draft-07/schema"
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,15 +5,15 @@
   "yaml.hover": true,
   "yaml.schemas": {
     "./schema/namelist.json": [
-      "./data/madoka/puella.yaml",
-      "./data/kazumi/puella.yaml",
-      "./data/oriko/puella.yaml",
-      "./data/suzune/puella.yaml",
-      "./data/tart/puella.yaml",
-      "./data/magireco/puella.yaml"
+      "/data/madoka/puella.yaml",
+      "/data/kazumi/puella.yaml",
+      "/data/oriko/puella.yaml",
+      "/data/suzune/puella.yaml",
+      "/data/tart/puella.yaml",
+      "/data/magireco/puella.yaml"
     ],
     "https://json.schemastore.org/github-action": [
-      "./github/workflows/*.yml"
+      "/github/workflows/*.yml"
     ],
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
       "./data/tart/puella.yaml",
       "./data/magireco/puella.yaml"
     ],
-    "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/github-action.json": [
+    "https://json.schemastore.org/github-action": [
       "./github/workflows/*.yml"
     ],
   }

--- a/Rakefile
+++ b/Rakefile
@@ -66,6 +66,7 @@ end
 
 def puella_all_name_list
   puella_name_files
+    .map { |file| file[0] == '/' ? file[1..] : file }
     .map { |file| Pathname(file) }
     .map { |path| Reader.load(path) }
     .flatten

--- a/spec/test_yaml_schema.rb
+++ b/spec/test_yaml_schema.rb
@@ -41,9 +41,11 @@ class YamlSchemaValidation < Minitest::Test
       .reject { |schema_file| schema_file.start_with?('https://') }
       .transform_keys { |schema_file| Pathname(schema_file) }
       .transform_keys { |pathname| JSONSchemer.schema(pathname) }
-      .transform_values do |values|
-        values.map { |file| file[0] == '/' ? file[1..] : file }
-      end
+      .transform_values(&method(:extract))
+  end
+
+  def extract(values)
+    values.map { |file| file[0] == '/' ? file[1..] : file }
   end
 
   PATTERN_YOMI = /^[\p{Hiragana}ー]+$/

--- a/spec/test_yaml_schema.rb
+++ b/spec/test_yaml_schema.rb
@@ -41,6 +41,9 @@ class YamlSchemaValidation < Minitest::Test
       .reject { |schema_file| schema_file.start_with?('https://') }
       .transform_keys { |schema_file| Pathname(schema_file) }
       .transform_keys { |pathname| JSONSchemer.schema(pathname) }
+      .transform_values do |values|
+        values.map { |file| file[0] == '/' ? file[1..] : file }
+      end
   end
 
   PATTERN_YOMI = /^[\p{Hiragana}ー]+$/


### PR DESCRIPTION
* GitHub Actionsのやつは短いURLがあるので
  * https://www.schemastore.org/json/
* 対象のyamlの指定方法は、リポジトリルートからのglobパターン
* vscode自体にjsonスキーマでバリデーションする設定があるので追加
  * https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings