### PR TITLE
リリース作成Actionを変更

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,17 +16,17 @@ jobs:
     name: Create Release
     runs-on: ubuntu-20.04
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 1
-      - name: setup ruby
+      - name: Setup Ruby
         uses: ruby/setup-ruby@v1.61.0
         with:
           bundler-cache: true
-      - name: build
+      - name: Build
         run: bundle exec rake
-      - name: Get version from tag
+      - name: Get Version from Tag
         id: tag_name
         run: |
           echo ::set-output name=current_version::${GITHUB_REF#refs/tags/v}
@@ -37,11 +37,11 @@ jobs:
         with:
           version: ${{ steps.tag_name.outputs.current_version }}
           path: ./CHANGELOG.md
-      - name: rename files to add version
+      - name: Rename Files to Add Version
         run: |
           rename.ul .txt _v${{ steps.changelog_reader.outputs.version }}.txt build/*.txt
           mv build/SKK-JISYO.magica build/SKK-JISYO.magica.v${{ steps.changelog_reader.outputs.version }}
-      - name: list build files
+      - name: List Build Files
         run: |
           ls ./build/*
       - name: Create Release and Upload Assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,22 +44,15 @@ jobs:
       - name: list build files
         run: |
           ls ./build/*
-      - name: Create Release
+      - name: Create Release and Upload Assets
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          name: ${{ github.ref }}
           body: ${{ steps.changelog_reader.outputs.changes }}
           draft: false
           prerelease: false
-      - name: Upload Release Assets
-        uses: alexellis/upload-assets@0.2.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_paths: '["./build/*"]'
-          asset_content_type: text/plain
+          files: "./build/*"


### PR DESCRIPTION
[actions/create-release](https://github.com/actions/create-release)がもうメンテナンスされないそうなので変更

変更先は[softprops/action-gh-release](https://github.com/softprops/action-gh-release)
* 候補として挙がっていた
* star数多い
* パラメータ名が元のに近い
* 複数ファイルアップロードが可能っぽい