### PR TITLE
由良蛍、真井あかり(表記のみ)追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 このプロジェクトは [Semantic Versioning](https://semver.org/spec/v2.0.0.html) に従います。
 
 ## [Unreleased]
+### Added
+- 由良蛍 追加
 
 ## [1.9.0] - 2021-08-15
 ### Added

--- a/data/magireco/puella.yaml
+++ b/data/magireco/puella.yaml
@@ -571,6 +571,16 @@
     kaki: 紗枝
     yomi: さえ
 - sei:
+    kaki: 由良
+    yomi: ゆら
+  mei:
+    kaki: 蛍
+    yomi: ほたる
+- sei:
+    kaki: 真井
+  mei:
+    kaki: あかり
+- sei:
     kaki: 入名
   mei:
     kaki: クシュ


### PR DESCRIPTION
辞書には由良蛍のみ追加。
真井あかりは読みが確定するまで出力しない