### PR TITLE
steepのバージョンを上げる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,4 @@ gem 'rake', '13.0.6'
 gem 'rubocop', '1.24.0', require: false
 gem 'rubocop-minitest', '0.17.0', require: false
 gem 'rubocop-rake', '0.6.0', require: false
-gem 'steep', '0.46.0'
+gem 'steep', '0.49.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4.1)
+    activesupport (7.0.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     ast (2.4.2)
     concurrent-ruby (1.1.9)
     ecma-re-validator (0.3.0)
       regexp_parser (~> 2.0)
-    ffi (1.15.4)
+    ffi (1.15.5)
     hana (1.3.7)
-    i18n (1.8.11)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     json_schemer (0.2.18)
       ecma-re-validator (~> 0.3)
@@ -21,7 +20,7 @@ GEM
       regexp_parser (~> 2.0)
       uri_template (~> 0.7)
     language_server-protocol (3.16.0.3)
-    listen (3.7.0)
+    listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     minitest (5.15.0)
@@ -30,10 +29,10 @@ GEM
       ast (~> 2.4.1)
     rainbow (3.0.0)
     rake (13.0.6)
-    rb-fsevent (0.11.0)
+    rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbs (1.6.2)
+    rbs (2.2.2)
     regexp_parser (2.2.0)
     rexml (3.2.5)
     rubocop (1.24.0)
@@ -52,14 +51,14 @@ GEM
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
     ruby-progressbar (1.11.0)
-    steep (0.46.0)
+    steep (0.49.1)
       activesupport (>= 5.1)
       language_server-protocol (>= 3.15, < 4.0)
       listen (~> 3.0)
       parallel (>= 1.0.0)
       parser (>= 3.0)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (>= 1.2.0)
+      rbs (>= 2.2.0)
       terminal-table (>= 2, < 4)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -67,7 +66,6 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
     uri_template (0.7.0)
-    zeitwerk (2.4.2)
 
 PLATFORMS
   x86_64-linux
@@ -79,7 +77,7 @@ DEPENDENCIES
   rubocop (= 1.24.0)
   rubocop-minitest (= 0.17.0)
   rubocop-rake (= 0.6.0)
-  steep (= 0.46.0)
+  steep (= 0.49.1)
 
 BUNDLED WITH
    2.3.3

--- a/lib/ime/collection.rb
+++ b/lib/ime/collection.rb
@@ -16,7 +16,7 @@ module IME
       end
 
       def ==(other)
-        [@yomi, @kaki, @category] == [other.yomi, other.kaki, other.category]
+        @yomi == other.yomi && @kaki == other.kaki && @category == other.category
       end
 
       def eql?(other)

--- a/sig/ime/collection.rbs
+++ b/sig/ime/collection.rbs
@@ -1,6 +1,10 @@
 module IME
   module Collection
-    class Entry[T]
+    class Entry[T < _HasEqual]
+      interface _HasEqual
+        def ==: (untyped) -> bool
+      end
+
       attr_reader yomi: String
       attr_reader kaki: String
       attr_reader category: T


### PR DESCRIPTION
Steepのv0.49.0で、RBSのジェネリクスの型パラメータの制約がサポートされたので使ってみる